### PR TITLE
corrected game title in comments

### DIFF
--- a/bird11/states/BaseState.lua
+++ b/bird11/states/BaseState.lua
@@ -1,6 +1,6 @@
 --[[
     GD50 2018
-    Match-3 Remake
+    Flappy Bird Remake
 
     -- BaseState Class --
 

--- a/bird12/states/BaseState.lua
+++ b/bird12/states/BaseState.lua
@@ -1,6 +1,6 @@
 --[[
     GD50 2018
-    Match-3 Remake
+    Flappy Bird Remake
 
     -- BaseState Class --
 


### PR DESCRIPTION
In the comment at the top of the file "BaseState.lua" in both folders "bird11" and "bird12" the game title is "Match-3 Remake" instead of "Flappy Bird Remake".